### PR TITLE
Implement VerifiableCredential/Presentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
 
     - name: Build + Test
       run: ./gradlew build
+      env:
+        GPR_USER: youngjoon-lee  # TODO: use the common account
+        GPR_API_KEY: ${{ secrets.YJ_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,5 @@ jobs:
     - name: Build + Test
       run: ./gradlew build
       env:
-        GPR_USER: youngjoon-lee  # TODO: use the common account
+        GPR_USER: youngjoon-lee  # TODO: use the common account instead of this
         GPR_API_KEY: ${{ secrets.YJ_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 This SDK is for creating/verifying W3C Verifiable Credentials and Presentations.
 The behavior is compatible with the [Typescript SDK](https://github.com/decentralized-identity/did-jwt-vc) written by [DIF](https://identity.foundation).
 
+## Features
+
+- Creating/Verifying W3C Verifiable Credentials using JWT
+- Creating/Verifying W3C Verifiable Presentation using JWT
+
+Currently, only [external proof](https://www.w3.org/TR/vc-data-model/#proofs-signatures) using JWT is supported.
+The embedded proof, such as a Linked Data Signature, would be supported in the future.
+
+For more details, please see [Usages](#usage).
+
 ## Installation
 
 TBD

--- a/README.md
+++ b/README.md
@@ -1,2 +1,124 @@
-# vc-java
-Verifiable Credentials SDK in Java
+# Verifiable Credential SDK in Java 
+
+This SDK is for creating/verifying W3C Verifiable Credentials and Presentations.
+The behavior is compatible with the [Typescript SDK](https://github.com/decentralized-identity/did-jwt-vc) written by [DIF](https://identity.foundation).
+
+## Installation
+
+TBD
+
+## Usage
+
+### Creating a Verifiable Credential
+
+```java
+import java.security.PrivateKey;
+import org.medibloc.vc.model.Credential;
+import org.medibloc.vc.model.CredentialSubject;
+import org.medibloc.vc.model.Issuer;
+import org.medibloc.vc.verifiable.VerifiableCredential;
+import org.medibloc.vc.verifiable.jwt.JwtVerifiableCredential;
+
+// Prepare a Issuer object
+Issuer issuer = new Issuer("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm");
+issuer.addExtra("name", "Example University");  // You can add any extra info
+
+// Prepare a CredentialSubject object
+// The 'id' is optional. If you don't have an ID, you can use the default constructor.
+CredentialSubject credentialSubject = new CredentialSubject("did:panacea:7aR7Cg46JamVbJgk8azVgUm7Prd74ry1Uct87nZqL3ny");
+// Claims can be set as key-values.
+credentialSubject.addClaim("degree", new HashMap<String, Object>() {{
+    put("type", "BachelorDegree");
+    put("name", "Bachelor of Science and Arts");
+}});
+
+// Create a Credential which doesn't have any proof.
+Credential credential = Credential.builder()
+        .contexts(Arrays.asList("https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"))
+        .types(Arrays.asList("VerifiableCredential", "UniversityDegreeCredential"))
+        .id(new URL("http://example.edu/credentials/3732"))
+        .issuer(issuer)
+        .issuanceDate(new Date())
+        .credentialSubject(credentialSubject)
+        .build();
+
+System.out.println(credential.toJson());
+// {"@context":...,"credentialSubject":...}
+
+// Create a VerifiableCredential using a key pair
+// Currently, only external proof (JWT) is supported.
+// This example assumes that you already have a private key.
+PrivateKey privateKey = ...;
+
+VerifiableCredential vc = new JwtVerifiableCredential(
+        credential,
+        "ES256K",
+        "did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1",
+        privateKey
+);
+
+System.out.println(vc.serialize());
+// eyJraWQiOiJkaWQ6cGFuYWNlYTo3UHJkNzRyeTF......
+}
+```
+
+### Verifying a Verifiable Credential
+
+```java
+import java.security.PublicKey;
+import org.medibloc.vc.model.Credential;
+import org.medibloc.vc.verifiable.VerifiableCredential;
+
+// This example assumes that you already have a public key.
+// In the future, we will introduce the feature that resolves a public key from a DID document.
+VerifiableCredential vc = ...;
+PublicKey publicKey = ...;
+
+Credential credential = vc.verify(publicKey);
+```
+
+### Creating a Verifiable Presentation
+
+```java
+import java.security.PrivateKey;
+import org.medibloc.vc.model.Presentation;
+import org.medibloc.vc.verifiable.VerifiablePresentation;
+
+Presentation presentation = Presentation.builder()
+        .contexts(Arrays.asList("https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"))
+        .types(Arrays.asList("VerifiablePresentation", "CredentialManagerPresentation"))
+        .id(new URL("http://example.edu/presentations/1234"))
+        .verifiableCredentials(Collections.singletonList(vc))
+        .holder("did:panacea:nZqL3ny7aR7Cg46Jct87gk8azVgUmamVbJ7Prd74ry1U")
+        .build();
+
+System.out.println(credential.toJson());
+// {"@context":...}
+    
+PrivateKey privateKey = ...;
+VerifiablePresentation vp = new JwtVerifiablePresentation(
+    presentation,
+    "ES256K",
+    "did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1",
+    privateKey
+);
+
+System.out.println(vc.serialize());
+// eyJraWQiOiJkaWQ6cGFuYWNlYTo3UHJkNzRyeTF......
+}
+```
+
+### Verifying a Verifiable Presentation
+
+```java
+import java.security.PublicKey;
+import org.medibloc.vc.model.Presentation;
+import org.medibloc.vc.verifiable.VerifiablePresentation;
+
+// This example assumes that you already have a public key.
+// In the future, we will introduce the feature that resolves a public key from a DID document.
+VerifiablePresentation vp = ...;
+PublicKey publicKey = ...;
+
+Presentation presentation = vp.verify(publicKey);
+```

--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,14 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.9.8'
-    compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.8'
+    compile 'org.projectlombok:lombok:1.18.8'
     compile 'io.jsonwebtoken:jjwt-api:0.11.3-SNAPSHOT'
     compile 'io.jsonwebtoken:jjwt-jackson:0.11.3-SNAPSHOT'
     runtime 'io.jsonwebtoken:jjwt-impl:0.11.3-SNAPSHOT'
             // Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
             //'org.bouncycastle:bcprov-jdk15on:1.60',
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile 'junit:junit:4.12'
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,13 @@ sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
 repositories {
-    mavenLocal()
+    maven {
+        url = "https://maven.pkg.github.com/medibloc/jjwt"
+        credentials {
+            username = System.getenv("GPR_USER")
+            password = System.getenv("GPR_API_KEY")
+        }
+    }
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,18 @@ sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.9.8'
     compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
+    compile 'io.jsonwebtoken:jjwt-api:0.11.3-SNAPSHOT'
+    compile 'io.jsonwebtoken:jjwt-jackson:0.11.3-SNAPSHOT'
+    runtime 'io.jsonwebtoken:jjwt-impl:0.11.3-SNAPSHOT'
+            // Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
+            //'org.bouncycastle:bcprov-jdk15on:1.60',
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/src/main/java/org/medibloc/vc/VerifiableCredentialException.java
+++ b/src/main/java/org/medibloc/vc/VerifiableCredentialException.java
@@ -1,0 +1,11 @@
+package org.medibloc.vc;
+
+public class VerifiableCredentialException extends Exception {
+    public VerifiableCredentialException(Exception e) {
+        super(e);
+    }
+
+    public VerifiableCredentialException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/medibloc/vc/lang/Assert.java
+++ b/src/main/java/org/medibloc/vc/lang/Assert.java
@@ -1,0 +1,9 @@
+package org.medibloc.vc.lang;
+
+public class Assert {
+    public static void notNull(Object obj, String msg) throws IllegalArgumentException {
+        if (obj == null) {
+            throw new IllegalArgumentException(msg);
+        }
+    }
+}

--- a/src/main/java/org/medibloc/vc/model/Credential.java
+++ b/src/main/java/org/medibloc/vc/model/Credential.java
@@ -1,0 +1,88 @@
+package org.medibloc.vc.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.*;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.lang.Assert;
+import org.medibloc.vc.verifiable.VerifiableCredential;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED;
+
+/**
+ * Represents a credential defined at https://www.w3.org/TR/vc-data-model/#credentials.
+ * Note that this class doesn't contain any <a href="https://www.w3.org/TR/vc-data-model/#proofs-signatures">proof</a>.
+ * This class can be a source of {@link VerifiableCredential} which contains proofs.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder(alphabetic = true)
+public class Credential extends JsonSerializable {
+    @NonNull
+    @JsonProperty(JSON_PROP_CONTEXTS)
+    @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+    private final List<String> contexts;
+    private final URL id;
+    @NonNull
+    @JsonProperty(JSON_PROP_TYPES)
+    @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+    private final List<String> types;
+    @NonNull
+    private final Issuer issuer;
+    @NonNull
+    private final CredentialSubject credentialSubject;
+    @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT)
+    private final Date issuanceDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT)
+    private final Date expirationDate;
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'hh:mm:ss'Z'";
+    public static final String JSON_PROP_CONTEXTS = "@context";
+    public static final String JSON_PROP_TYPES = "type";
+    public static final String JSON_PROP_CRED_SUB = "credentialSubject";
+
+    /**
+     * Overrides the parts of the Lombok default builder.
+     */
+    public static class CredentialBuilder {
+        private List<String> contexts;
+        private List<String> types;
+
+        static final String DEFAULT_CONTEXT = "https://www.w3.org/2018/credentials/v1";
+        static final String DEFAULT_TYPE = "VerifiableCredential";
+
+        /**
+         * Validate the contexts
+         */
+        public CredentialBuilder contexts(List<String> contexts) throws VerifiableCredentialException {
+            Assert.notNull(contexts, "contexts must not be null");
+            if (!contexts.contains(DEFAULT_CONTEXT)) {
+                throw new VerifiableCredentialException("contexts must contain the default context: " + DEFAULT_CONTEXT);
+            }
+            this.contexts = contexts;
+            return this;
+        }
+
+        /**
+         * Validate the types
+         */
+        public CredentialBuilder types(List<String> types) throws VerifiableCredentialException {
+            Assert.notNull(types, "types must not be null");
+            if (!types.contains(DEFAULT_TYPE)) {
+                throw new VerifiableCredentialException("types must contain the default type: " + DEFAULT_TYPE);
+            }
+            this.types = types;
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/medibloc/vc/model/CredentialSubject.java
+++ b/src/main/java/org/medibloc/vc/model/CredentialSubject.java
@@ -1,0 +1,47 @@
+package org.medibloc.vc.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a credentialSubject defined at https://www.w3.org/TR/vc-data-model/#credential-subject.
+ */
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder(alphabetic = true)
+public class CredentialSubject {
+    private final String id;
+    private final Map<String, Object> claims;
+
+    public CredentialSubject() {
+        this(null, new HashMap<String, Object>());  // id is optional
+    }
+
+    public CredentialSubject(String id) {
+        this(id, new HashMap<String, Object>());
+    }
+
+    // to unflatten key-values into a Map for JSON deserialization
+    // {"id":"id1","key1":"val1"} -> CredentialSubject{id:"id1", claims:{"key1":"value1"}}
+    @JsonAnySetter
+    public void addClaim(String key, Object value) {
+        this.claims.put(key, value);
+    }
+
+    // to flatten a Map for JSON serialization
+    // CredentialSubject{id:"id1", claims:{"key1":"value1"}} -> {"id":"id1","key1":"val1"}
+    @JsonAnyGetter
+    public Map<String, Object> getClaims() {
+        return claims;
+    }
+}

--- a/src/main/java/org/medibloc/vc/model/Issuer.java
+++ b/src/main/java/org/medibloc/vc/model/Issuer.java
@@ -50,6 +50,7 @@ public class Issuer {
         return extras;
     }
 
+    // This is like the type aliasing, so that the Extra class can be passed as 'Class' type arguments for Jackson.
     public static class Extras extends HashMap<String, Object> {
     }
 }

--- a/src/main/java/org/medibloc/vc/model/Issuer.java
+++ b/src/main/java/org/medibloc/vc/model/Issuer.java
@@ -1,0 +1,55 @@
+package org.medibloc.vc.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a issuer defined at https://www.w3.org/TR/vc-data-model/#issuer.
+ */
+@Getter
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder(alphabetic = true)
+public class Issuer {
+    @NonNull
+    private final String id;
+    @NonNull
+    private final Extras extras;
+
+    // only for JSON deserialization
+    private Issuer() {
+        this(null);
+    }
+
+    public Issuer(String id) {
+        this(id, new Extras());
+    }
+
+    public Issuer(String id, Extras extras) {
+        this.id = id;
+        this.extras = extras != null ? extras : new Extras();
+    }
+
+    // to unflatten key-values into a Map for JSON deserialization
+    // {"id":"id1","key1":"val1"} -> Issuer{id:"id1", extras:{"key1":"value1"}}
+    @JsonAnySetter
+    public void addExtra(String key, Object value) {
+        this.extras.put(key, value);
+    }
+
+    // to flatten a Map for JSON serialization
+    // Issuer{id:"id1", extras:{"key1":"value1"}} -> {"id":"id1","key1":"val1"}
+    @JsonAnyGetter
+    public Map<String, Object> getExtras() {
+        return extras;
+    }
+
+    public static class Extras extends HashMap<String, Object> {
+    }
+}

--- a/src/main/java/org/medibloc/vc/model/JsonSerializable.java
+++ b/src/main/java/org/medibloc/vc/model/JsonSerializable.java
@@ -1,0 +1,17 @@
+package org.medibloc.vc.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.EqualsAndHashCode;
+import org.medibloc.vc.VerifiableCredentialException;
+
+@EqualsAndHashCode
+class JsonSerializable {
+    public String toJson() throws VerifiableCredentialException {
+        try {
+            return new ObjectMapper().writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new VerifiableCredentialException(e);
+        }
+    }
+}

--- a/src/main/java/org/medibloc/vc/model/Presentation.java
+++ b/src/main/java/org/medibloc/vc/model/Presentation.java
@@ -1,0 +1,83 @@
+package org.medibloc.vc.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.*;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.lang.Assert;
+import org.medibloc.vc.verifiable.VerifiableCredential;
+import org.medibloc.vc.verifiable.VerifiablePresentation;
+
+import java.net.URL;
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED;
+
+/**
+ * Represents a presentation defined at https://www.w3.org/TR/vc-data-model/#presentations-0.
+ * Note that this class doesn't contain any <a href="https://www.w3.org/TR/vc-data-model/#proofs-signatures">proof</a>.
+ * This class can be a source of {@link VerifiablePresentation} which contains proofs.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder(alphabetic = true)
+public class Presentation extends JsonSerializable {
+    @NonNull
+    @JsonProperty(JSON_PROP_CONTEXTS)
+    @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+    private final List<String> contexts;
+    private final URL id;
+    @NonNull
+    @JsonProperty(JSON_PROP_TYPES)
+    @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+    private final List<String> types;
+    @NonNull
+    @JsonProperty(JSON_PROP_VERIFIABLE_CREDS)
+    private final List<VerifiableCredential> verifiableCredentials;
+    @NonNull
+    private final String holder;  //TODO: make sure about its type
+
+    public static final String JSON_PROP_CONTEXTS = "@context";
+    public static final String JSON_PROP_TYPES = "type";
+    public static final String JSON_PROP_VERIFIABLE_CREDS = "verifiableCredential";
+
+    /**
+     * Overrides the parts of the Lombok default builder.
+     */
+    public static class PresentationBuilder {
+        private List<String> contexts;
+        private List<String> types;
+
+        static final String DEFAULT_CONTEXT = "https://www.w3.org/2018/credentials/v1";
+        static final String DEFAULT_TYPE = "VerifiablePresentation";
+
+        /**
+         * Validate the contexts
+         */
+        public PresentationBuilder contexts(List<String> contexts) throws VerifiableCredentialException {
+            Assert.notNull(contexts, "contexts must not be null");
+            if (!contexts.contains(DEFAULT_CONTEXT)) {
+                throw new VerifiableCredentialException("contexts must contain the default context: " + DEFAULT_CONTEXT);
+            }
+            this.contexts = contexts;
+            return this;
+        }
+
+        /**
+         * Validate the types
+         */
+        public PresentationBuilder types(List<String> types) throws VerifiableCredentialException {
+            Assert.notNull(types, "types must not be null");
+            if (!types.contains(DEFAULT_TYPE)) {
+                throw new VerifiableCredentialException("types must contain the default type: " + DEFAULT_TYPE);
+            }
+            this.types = types;
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/medibloc/vc/verifiable/VerifiableCredential.java
+++ b/src/main/java/org/medibloc/vc/verifiable/VerifiableCredential.java
@@ -1,0 +1,39 @@
+package org.medibloc.vc.verifiable;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.model.Credential;
+import org.medibloc.vc.verifiable.jwt.JwtVerifiableCredential;
+
+import java.io.IOException;
+import java.security.PublicKey;
+
+@JsonDeserialize(using = VerifiableCredential.JsonDeserializer.class)
+public interface VerifiableCredential {
+    public Credential verify(PublicKey publicKey) throws VerifiableCredentialException;
+    public String serialize();
+
+    public class JsonDeserializer extends StdDeserializer<VerifiableCredential> {
+        public JsonDeserializer() {
+            this(null);
+        }
+
+        public JsonDeserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public VerifiableCredential deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+            JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+            if (node.isTextual()) {
+                return new JwtVerifiableCredential(node.asText());
+            }
+            throw new IOException("unexpected value type: " + node.getNodeType());
+        }
+    }
+}

--- a/src/main/java/org/medibloc/vc/verifiable/VerifiablePresentation.java
+++ b/src/main/java/org/medibloc/vc/verifiable/VerifiablePresentation.java
@@ -1,0 +1,11 @@
+package org.medibloc.vc.verifiable;
+
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.model.Presentation;
+
+import java.security.PublicKey;
+
+public interface VerifiablePresentation {
+    public Presentation verify(PublicKey publicKey) throws VerifiableCredentialException;
+    public String serialize();
+}

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
@@ -36,7 +36,7 @@ class JwtVerifiable {
                     .signWith(privateKey, SignatureAlgorithm.forName(algo))
                     .serializeToJsonWith(new JacksonSerializer(new ObjectMapper()))
                     .compact();
-        } catch (Exception e) {
+        } catch (JwtException e) {
             throw new VerifiableCredentialException(e);
         }
     }
@@ -48,7 +48,7 @@ class JwtVerifiable {
                     .deserializeJsonWith(new JacksonDeserializer(classMap))
                     .build()
                     .parseClaimsJws(this.jws);
-        } catch (Exception e) {
+        } catch (JwtException e) {
             throw new VerifiableCredentialException(e);
         }
     }

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
@@ -1,0 +1,59 @@
+package org.medibloc.vc.verifiable.jwt;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.jackson.io.JacksonDeserializer;
+import io.jsonwebtoken.jackson.io.JacksonSerializer;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.lang.Assert;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+class JwtVerifiable {
+    @JsonValue
+    @NonNull
+    private final String jws;
+
+    JwtVerifiable(String algo, String keyId, PrivateKey privateKey, JwtBuilder jwtBuilder) throws VerifiableCredentialException {
+        Assert.notNull(algo, "keyType must not be null");
+        Assert.notNull(keyId, "keyId must not be null");
+        Assert.notNull(privateKey, "privateKey must not be null");
+        Assert.notNull(jwtBuilder, "jwtBuilder must not be null");
+
+        try {
+            this.jws = jwtBuilder
+                    .setHeaderParam("kid", keyId)
+                    .signWith(privateKey, SignatureAlgorithm.forName(algo))
+                    .serializeToJsonWith(new JacksonSerializer(new ObjectMapper()))
+                    .compact();
+        } catch (Exception e) {
+            throw new VerifiableCredentialException(e);
+        }
+    }
+
+    Jws<Claims> verifyJwt(PublicKey publicKey, Map<String, Class> classMap) throws VerifiableCredentialException {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .deserializeJsonWith(new JacksonDeserializer(classMap))
+                    .build()
+                    .parseClaimsJws(this.jws);
+        } catch (Exception e) {
+            throw new VerifiableCredentialException(e);
+        }
+    }
+
+    public String serialize() {
+        return this.jws;
+    }
+}

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredential.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredential.java
@@ -29,6 +29,11 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_E
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class JwtVerifiableCredential extends JwtVerifiable implements VerifiableCredential {
+    private static final Map<String, Class> classMap = new HashMap<String, Class>(){{
+        put(JWT_CLAIM_NAME_VC, VcClaim.class);
+        put(JWT_CLAIM_NAME_ISSUER, Issuer.Extras.class);
+    }};
+
     public JwtVerifiableCredential(Credential credential, String jwsAlgo, String keyId, PrivateKey privateKey) throws VerifiableCredentialException {
         super(jwsAlgo, keyId, privateKey, encode(credential));
     }
@@ -39,10 +44,7 @@ public class JwtVerifiableCredential extends JwtVerifiable implements Verifiable
 
     @Override
     public Credential verify(PublicKey publicKey) throws VerifiableCredentialException {
-        Map<String, Class> classMap = new HashMap<String, Class>();
-        classMap.put(JWT_CLAIM_NAME_VC, VcClaim.class);
-        classMap.put(JWT_CLAIM_NAME_ISSUER, Issuer.Extras.class);
-        return decode(super.verifyJwt(publicKey, classMap).getBody());
+        return decode(super.verifyJwt(publicKey, this.classMap).getBody());
     }
 
     // https://www.w3.org/TR/vc-data-model/#json-web-token-extensions

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredential.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredential.java
@@ -1,0 +1,130 @@
+package org.medibloc.vc.verifiable.jwt;
+
+import com.fasterxml.jackson.annotation.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import lombok.*;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.model.Credential;
+import org.medibloc.vc.model.CredentialSubject;
+import org.medibloc.vc.model.Issuer;
+import org.medibloc.vc.verifiable.VerifiableCredential;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED;
+
+/**
+ * A verifiable credential in the form of external proof using JWT.
+ * See https://www.w3.org/TR/vc-data-model/#proofs-signatures.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class JwtVerifiableCredential extends JwtVerifiable implements VerifiableCredential {
+    public JwtVerifiableCredential(Credential credential, String jwsAlgo, String keyId, PrivateKey privateKey) throws VerifiableCredentialException {
+        super(jwsAlgo, keyId, privateKey, encode(credential));
+    }
+
+    public JwtVerifiableCredential(String jws) {
+        super(jws);
+    }
+
+    @Override
+    public Credential verify(PublicKey publicKey) throws VerifiableCredentialException {
+        Map<String, Class> classMap = new HashMap<String, Class>();
+        classMap.put(JWT_CLAIM_NAME_VC, VcClaim.class);
+        classMap.put(JWT_CLAIM_NAME_ISSUER, Issuer.Extras.class);
+        return decode(super.verifyJwt(publicKey, classMap).getBody());
+    }
+
+    // https://www.w3.org/TR/vc-data-model/#json-web-token-extensions
+    private static final String JWT_CLAIM_NAME_VC = "vc";
+    private static final String JWT_CLAIM_NAME_ISSUER = "issuer";  // for extra infos of the issuer
+
+    /**
+     * Encode a credential to a JWT payload, as described at https://www.w3.org/TR/vc-data-model/#jwt-encoding
+     */
+    private static JwtBuilder encode(Credential credential) {
+        // Set JWT registered claims (iss, exp, ...)
+        JwtBuilder builder = Jwts.builder()
+                .setIssuer(credential.getIssuer().getId())
+                .setNotBefore(credential.getIssuanceDate());
+        if (credential.getCredentialSubject().getId() != null) {
+            builder.setSubject(credential.getCredentialSubject().getId());
+        }
+        if (credential.getExpirationDate() != null) {
+            builder.setExpiration(credential.getExpirationDate());
+        }
+        if (credential.getId() != null) {
+            builder.setId(credential.getId().toString());
+        }
+
+        // Set JWT private claims
+        builder.claim(JWT_CLAIM_NAME_VC, VcClaim.from(credential));
+        builder.claim(JWT_CLAIM_NAME_ISSUER, credential.getIssuer().getExtras());
+
+        return builder;
+    }
+
+    /**
+     * Decodes a JWT payload to a {@link Credential}, as described at https://www.w3.org/TR/vc-data-model/#jwt-decoding.
+     */
+    private static Credential decode(Claims claims) throws VerifiableCredentialException {
+        VcClaim vcClaim = claims.get(JWT_CLAIM_NAME_VC, VcClaim.class);
+        Issuer.Extras issuerExtras = claims.get(JWT_CLAIM_NAME_ISSUER, Issuer.Extras.class);
+
+        try {
+            Credential.CredentialBuilder builder =  Credential.builder()
+                    .contexts(vcClaim.getContexts())
+                    .types(vcClaim.getTypes())
+                    .credentialSubject(new CredentialSubject(claims.getSubject(), vcClaim.getCredentialSubjectClaims()))
+                    .issuer(new Issuer(claims.getIssuer(), issuerExtras))
+                    .issuanceDate(claims.getNotBefore());
+
+            if (claims.getExpiration() != null) {
+                builder = builder.expirationDate(claims.getExpiration());
+            }
+            if (claims.getId() != null) {
+                builder = builder.id(new URL(claims.getId()));
+            }
+
+            return builder.build();
+        } catch (MalformedURLException e) {
+            throw new VerifiableCredentialException(e);
+        }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @EqualsAndHashCode
+    @ToString
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder(alphabetic = true)
+    public static class VcClaim {
+        @JsonProperty(Credential.JSON_PROP_CONTEXTS)
+        @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+        private final List<String> contexts;
+        @JsonProperty(Credential.JSON_PROP_TYPES)
+        @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+        private final List<String> types;
+        @JsonProperty(Credential.JSON_PROP_CRED_SUB)
+        private final Map<String, Object> credentialSubjectClaims;
+
+        // only for JSON deserialization
+        public VcClaim() {
+            this(null, null, null);
+        }
+
+        static VcClaim from(Credential credential) {
+            return new VcClaim(credential.getContexts(), credential.getTypes(), credential.getCredentialSubject().getClaims());
+        }
+    }
+}

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentation.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentation.java
@@ -1,0 +1,110 @@
+package org.medibloc.vc.verifiable.jwt;
+
+import com.fasterxml.jackson.annotation.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import lombok.*;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.model.Presentation;
+import org.medibloc.vc.verifiable.VerifiableCredential;
+import org.medibloc.vc.verifiable.VerifiablePresentation;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
+import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED;
+
+/**
+ * A verifiable presentation in the form of external proof using JWT.
+ * See https://www.w3.org/TR/vc-data-model/#proofs-signatures.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class JwtVerifiablePresentation extends JwtVerifiable implements VerifiablePresentation {
+    public JwtVerifiablePresentation(Presentation presentation, String jwsAlgo, String keyId, PrivateKey privateKey) throws VerifiableCredentialException {
+        super(jwsAlgo, keyId, privateKey, encode(presentation));
+    }
+
+    public JwtVerifiablePresentation(String jws) {
+        super(jws);
+    }
+
+    @Override
+    public Presentation verify(PublicKey publicKey) throws VerifiableCredentialException {
+        Map<String, Class> classMap = new HashMap<String, Class>();
+        classMap.put(JWT_CLAIM_NAME_VP, VpClaim.class);
+        return decode(super.verifyJwt(publicKey, classMap).getBody());
+    }
+
+    // https://www.w3.org/TR/vc-data-model/#json-web-token-extensions
+    private static final String JWT_CLAIM_NAME_VP = "vp";
+
+    /**
+     * Encode a presentation to a JWT payload.
+     */
+    private static JwtBuilder encode(Presentation presentation) throws VerifiableCredentialException {
+        // Set JWT registered claims (iss, exp, ...)
+        JwtBuilder builder = Jwts.builder()
+                .setIssuer(presentation.getHolder());
+        if (presentation.getId() != null) {
+            builder.setId(presentation.getId().toString());
+        }
+
+        // Set JWT private claims
+        builder.claim(JWT_CLAIM_NAME_VP, VpClaim.from(presentation));
+
+        return builder;
+    }
+
+    /**
+     * Decodes a JWT payload to a {@link Presentation}.
+     */
+    private static Presentation decode(Claims claims) throws VerifiableCredentialException {
+        VpClaim vpClaim = claims.get(JWT_CLAIM_NAME_VP, VpClaim.class);
+        try {
+            return Presentation.builder()
+                    .contexts(vpClaim.getContexts())
+                    .types(vpClaim.getTypes())
+                    .verifiableCredentials(vpClaim.getVerifiableCredentials())
+                    .holder(claims.getIssuer())
+                    .id(new URL(claims.getId()))
+                    .build();
+        } catch (MalformedURLException e) {
+            throw new VerifiableCredentialException(e);
+        }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @EqualsAndHashCode
+    @ToString
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder(alphabetic = true)
+    public static class VpClaim {
+        @JsonProperty(Presentation.JSON_PROP_CONTEXTS)
+        @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+        private final List<String> contexts;
+        @JsonProperty(Presentation.JSON_PROP_TYPES)
+        @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+        private final List<String> types;
+        @JsonProperty(Presentation.JSON_PROP_VERIFIABLE_CREDS)
+        @JsonFormat(with = {ACCEPT_SINGLE_VALUE_AS_ARRAY, WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED})
+        private final List<VerifiableCredential> verifiableCredentials;
+
+        // only for JSON deserialization
+        public VpClaim() {
+            this(null, null, null);
+        }
+
+        static VpClaim from(Presentation presentation) {
+            return new VpClaim(presentation.getContexts(), presentation.getTypes(), presentation.getVerifiableCredentials());
+        }
+    }
+}

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentation.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentation.java
@@ -28,6 +28,10 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_E
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class JwtVerifiablePresentation extends JwtVerifiable implements VerifiablePresentation {
+    private static final Map<String, Class> classMap = new HashMap<String, Class>(){{
+        put(JWT_CLAIM_NAME_VP, VpClaim.class);
+    }};
+
     public JwtVerifiablePresentation(Presentation presentation, String jwsAlgo, String keyId, PrivateKey privateKey) throws VerifiableCredentialException {
         super(jwsAlgo, keyId, privateKey, encode(presentation));
     }
@@ -38,8 +42,6 @@ public class JwtVerifiablePresentation extends JwtVerifiable implements Verifiab
 
     @Override
     public Presentation verify(PublicKey publicKey) throws VerifiableCredentialException {
-        Map<String, Class> classMap = new HashMap<String, Class>();
-        classMap.put(JWT_CLAIM_NAME_VP, VpClaim.class);
         return decode(super.verifyJwt(publicKey, classMap).getBody());
     }
 

--- a/src/test/java/org/medibloc/vc/model/CredentialSubjectTest.java
+++ b/src/test/java/org/medibloc/vc/model/CredentialSubjectTest.java
@@ -1,0 +1,42 @@
+package org.medibloc.vc.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class CredentialSubjectTest {
+    @Test
+    public void jsonWithoutClaims() throws IOException {
+        CredentialSubject cs = new CredentialSubject("id1");
+
+        String json = new ObjectMapper().writeValueAsString(cs);
+        assertEquals("{\"id\":\"id1\"}", json);
+
+        assertEquals(cs, new ObjectMapper().readValue(json, CredentialSubject.class));
+    }
+
+    @Test
+    public void jsonWithClaims() throws IOException {
+        CredentialSubject cs = new CredentialSubject("id1");
+        cs.addClaim("key1", "value1");
+
+        String json = new ObjectMapper().writeValueAsString(cs);
+        assertEquals("{\"id\":\"id1\",\"key1\":\"value1\"}", json);
+
+        assertEquals(cs, new ObjectMapper().readValue(json, CredentialSubject.class));
+    }
+
+    @Test
+    public void jsonWithoutId() throws IOException {
+        CredentialSubject cs = new CredentialSubject();
+        cs.addClaim("key1", "value1");
+
+        String json = new ObjectMapper().writeValueAsString(cs);
+        assertEquals("{\"key1\":\"value1\"}", json);
+
+        assertEquals(cs, new ObjectMapper().readValue(json, CredentialSubject.class));
+    }
+}

--- a/src/test/java/org/medibloc/vc/model/CredentialTest.java
+++ b/src/test/java/org/medibloc/vc/model/CredentialTest.java
@@ -1,0 +1,81 @@
+package org.medibloc.vc.model;
+
+import org.junit.Test;
+import org.medibloc.vc.VerifiableCredentialException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
+
+public class CredentialTest {
+    @Test
+    public void builder() throws MalformedURLException, ParseException, VerifiableCredentialException {
+        Credential vc = buildCredential();
+
+        assertEquals(
+                Arrays.asList(Credential.CredentialBuilder.DEFAULT_CONTEXT, "https://www.w3.org/2018/credentials/examples/v1"),
+                vc.getContexts()
+        );
+        assertEquals(
+                Arrays.asList(Credential.CredentialBuilder.DEFAULT_TYPE, "UniversityDegreeCredential"),
+                vc.getTypes()
+        );
+        assertEquals("http://example.edu/credentials/3732", vc.getId().toString());
+        assertNotNull(vc.getIssuer());
+        assertNotNull(vc.getCredentialSubject());
+        assertNotNull(vc.getIssuanceDate());
+        assertNull(vc.getExpirationDate());
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void buildWithoutDefaultContext() throws VerifiableCredentialException {
+        Credential.builder().contexts(Collections.singletonList("https://something.com/v1"));
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void buildWithoutDefaultType() throws VerifiableCredentialException {
+        Credential.builder().types(Collections.singletonList("https://something.com/v1"));
+    }
+
+    @Test
+    public void toJson() throws MalformedURLException, VerifiableCredentialException, ParseException {
+        Credential vc = buildCredential();
+        assertEquals(
+                "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://www.w3.org/2018/credentials/examples/v1\"],\"credentialSubject\":{\"id\":\"did:panacea:7aR7Cg46JamVbJgk8azVgUm7Prd74ry1Uct87nZqL3ny\",\"degree\":{\"name\":\"Bachelor of Science and Arts\",\"type\":\"BachelorDegree\"}},\"id\":\"http://example.edu/credentials/3732\",\"issuanceDate\":\"2020-10-05T12:30:50Z\",\"issuer\":{\"id\":\"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm\",\"name\":\"Example University\"},\"type\":[\"VerifiableCredential\",\"UniversityDegreeCredential\"]}",
+                vc.toJson()
+        );
+    }
+
+    public static Credential buildCredential() throws MalformedURLException, ParseException, VerifiableCredentialException {
+        // Prepare the issuer information
+        Issuer issuer = new Issuer("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm");
+        issuer.addExtra("name", "Example University");
+
+        // Prepare a credentialSubject
+        CredentialSubject credentialSubject = new CredentialSubject("did:panacea:7aR7Cg46JamVbJgk8azVgUm7Prd74ry1Uct87nZqL3ny");
+        credentialSubject.addClaim("degree", new HashMap<String, Object>() {{
+            put("type", "BachelorDegree");
+            put("name", "Bachelor of Science and Arts");
+        }});
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+        // Create a VerifiableCredential
+        return Credential.builder()
+                .contexts(Arrays.asList(Credential.CredentialBuilder.DEFAULT_CONTEXT, "https://www.w3.org/2018/credentials/examples/v1"))
+                .types(Arrays.asList(Credential.CredentialBuilder.DEFAULT_TYPE, "UniversityDegreeCredential"))
+                .id(new URL("http://example.edu/credentials/3732"))
+                .issuer(issuer)
+                .issuanceDate(dateFormat.parse("2020-10-05 12:30:50"))
+                .credentialSubject(credentialSubject)
+                .build();
+    }
+}

--- a/src/test/java/org/medibloc/vc/model/IssuerTest.java
+++ b/src/test/java/org/medibloc/vc/model/IssuerTest.java
@@ -1,0 +1,32 @@
+package org.medibloc.vc.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.medibloc.vc.model.Issuer;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class IssuerTest {
+    @Test
+    public void jsonWithoutExtra() throws IOException {
+        Issuer issuer = new Issuer("id1");
+
+        String json = new ObjectMapper().writeValueAsString(issuer);
+        assertEquals("{\"id\":\"id1\"}", json);
+
+        assertEquals(issuer, new ObjectMapper().readValue(json, Issuer.class));
+    }
+
+    @Test
+    public void jsonWithExtra() throws IOException {
+        Issuer issuer = new Issuer("id1");
+        issuer.addExtra("name", "my name");
+
+        String json = new ObjectMapper().writeValueAsString(issuer);
+        assertEquals("{\"id\":\"id1\",\"name\":\"my name\"}", json);
+
+        assertEquals(issuer, new ObjectMapper().readValue(json, Issuer.class));
+    }
+}

--- a/src/test/java/org/medibloc/vc/model/PresentationTest.java
+++ b/src/test/java/org/medibloc/vc/model/PresentationTest.java
@@ -1,0 +1,65 @@
+package org.medibloc.vc.model;
+
+import org.junit.Test;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.verifiable.VerifiableCredential;
+import org.medibloc.vc.verifiable.jwt.JwtVerifiableCredential;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class PresentationTest {
+    @Test
+    public void builder() throws MalformedURLException, VerifiableCredentialException {
+        Presentation presentation = buildPresentation();
+
+        assertEquals(
+                Arrays.asList(Presentation.PresentationBuilder.DEFAULT_CONTEXT, "https://www.w3.org/2018/credentials/examples/v1"),
+                presentation.getContexts()
+        );
+        assertEquals(
+                Arrays.asList(Presentation.PresentationBuilder.DEFAULT_TYPE, "CredentialManagerPresentation"),
+                presentation.getTypes()
+        );
+        assertEquals("http://example.edu/presentations/1234", presentation.getId().toString());
+        assertEquals("did:panacea:nZqL3ny7aR7Cg46Jct87gk8azVgUmamVbJ7Prd74ry1U", presentation.getHolder());
+        assertEquals(1, presentation.getVerifiableCredentials().size());
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void buildWithoutDefaultContext() throws VerifiableCredentialException {
+        Credential.builder().contexts(Collections.singletonList("https://something.com/v1"));
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void buildWithoutDefaultType() throws VerifiableCredentialException {
+        Credential.builder().types(Collections.singletonList("https://something.com/v1"));
+    }
+
+    @Test
+    public void toJson() throws IOException, VerifiableCredentialException, ParseException {
+        Presentation presentation = buildPresentation();
+        assertEquals(
+                "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://www.w3.org/2018/credentials/examples/v1\"],\"holder\":\"did:panacea:nZqL3ny7aR7Cg46Jct87gk8azVgUmamVbJ7Prd74ry1U\",\"id\":\"http://example.edu/presentations/1234\",\"type\":[\"VerifiablePresentation\",\"CredentialManagerPresentation\"],\"verifiableCredential\":[\"eyJraWQiOiJkaWQ6cGFuYWNlYTo3UHJkNzRyeTFVY3Q4N25acUwzbnk3YVI3Q2c0NkphbVZiSmdrOGF6VmdVbSNrZXkxIiwiYWxnIjoiRVMyNTZLIn0.eyJzdWIiOiJkaWQ6cGFuYWNlYTo3YVI3Q2c0NkphbVZiSmdrOGF6VmdVbTdQcmQ3NHJ5MVVjdDg3blpxTDNueSIsIm5iZiI6MTYwMTg1Nzg1MCwiaXNzIjoiZGlkOnBhbmFjZWE6N1ByZDc0cnkxVWN0ODduWnFMM255N2FSN0NnNDZKYW1WYkpnazhhelZnVW0iLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJ0eXBlIjoiQmFjaGVsb3JEZWdyZWUifX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJVbml2ZXJzaXR5RGVncmVlQ3JlZGVudGlhbCJdLCJAY29udGV4dCI6WyJodHRwczpcL1wvd3d3LnczLm9yZ1wvMjAxOFwvY3JlZGVudGlhbHNcL3YxIiwiaHR0cHM6XC9cL3d3dy53My5vcmdcLzIwMThcL2NyZWRlbnRpYWxzXC9leGFtcGxlc1wvdjEiXX0sImp0aSI6Imh0dHA6XC9cL2V4YW1wbGUuZWR1XC9jcmVkZW50aWFsc1wvMzczMiIsImlzc3VlciI6eyJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In19.9e33oCgJlPqpTwTOe2b45PtaMvlCTwY84imbdvCUFaZ3btV4bUUHXj6qivYgtEMqLjSLLvY3dVLflv8LpD8wvA\"]}",
+                presentation.toJson()
+        );
+    }
+
+    public static Presentation buildPresentation() throws MalformedURLException, VerifiableCredentialException {
+        VerifiableCredential vc = new JwtVerifiableCredential("eyJraWQiOiJkaWQ6cGFuYWNlYTo3UHJkNzRyeTFVY3Q4N25acUwzbnk3YVI3Q2c0NkphbVZiSmdrOGF6VmdVbSNrZXkxIiwiYWxnIjoiRVMyNTZLIn0.eyJzdWIiOiJkaWQ6cGFuYWNlYTo3YVI3Q2c0NkphbVZiSmdrOGF6VmdVbTdQcmQ3NHJ5MVVjdDg3blpxTDNueSIsIm5iZiI6MTYwMTg1Nzg1MCwiaXNzIjoiZGlkOnBhbmFjZWE6N1ByZDc0cnkxVWN0ODduWnFMM255N2FSN0NnNDZKYW1WYkpnazhhelZnVW0iLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJ0eXBlIjoiQmFjaGVsb3JEZWdyZWUifX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJVbml2ZXJzaXR5RGVncmVlQ3JlZGVudGlhbCJdLCJAY29udGV4dCI6WyJodHRwczpcL1wvd3d3LnczLm9yZ1wvMjAxOFwvY3JlZGVudGlhbHNcL3YxIiwiaHR0cHM6XC9cL3d3dy53My5vcmdcLzIwMThcL2NyZWRlbnRpYWxzXC9leGFtcGxlc1wvdjEiXX0sImp0aSI6Imh0dHA6XC9cL2V4YW1wbGUuZWR1XC9jcmVkZW50aWFsc1wvMzczMiIsImlzc3VlciI6eyJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In19.9e33oCgJlPqpTwTOe2b45PtaMvlCTwY84imbdvCUFaZ3btV4bUUHXj6qivYgtEMqLjSLLvY3dVLflv8LpD8wvA");
+
+        return Presentation.builder()
+                .contexts(Arrays.asList(Presentation.PresentationBuilder.DEFAULT_CONTEXT, "https://www.w3.org/2018/credentials/examples/v1"))
+                .types(Arrays.asList(Presentation.PresentationBuilder.DEFAULT_TYPE, "CredentialManagerPresentation"))
+                .id(new URL("http://example.edu/presentations/1234"))
+                .verifiableCredentials(Collections.singletonList(vc))
+                .holder("did:panacea:nZqL3ny7aR7Cg46Jct87gk8azVgUmamVbJ7Prd74ry1U")
+                .build();
+    }
+}

--- a/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredentialTest.java
+++ b/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredentialTest.java
@@ -1,0 +1,54 @@
+package org.medibloc.vc.verifiable.jwt;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.Test;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.model.Credential;
+import org.medibloc.vc.model.CredentialTest;
+
+import java.net.MalformedURLException;
+import java.security.KeyPair;
+import java.text.ParseException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class JwtVerifiableCredentialTest {
+    @Test
+    public void createAndVerify() throws MalformedURLException, VerifiableCredentialException, ParseException {
+        Credential credential = CredentialTest.buildCredential();
+        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256K);
+
+        JwtVerifiableCredential vc = new JwtVerifiableCredential(
+                credential, "ES256K", credential.getIssuer().getId() + "#key1", keyPair.getPrivate()
+        );
+        assertNotNull(vc);
+
+        assertEquals(credential, vc.verify(keyPair.getPublic()));
+        assertEquals(vc.getJws(), vc.serialize());
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void createWithInvalidAlgo() throws MalformedURLException, VerifiableCredentialException, ParseException {
+        Credential credential = CredentialTest.buildCredential();
+        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256K);
+
+        new JwtVerifiableCredential(
+                credential, "INVALID", credential.getIssuer().getId() + "#key1", keyPair.getPrivate()
+        );
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void verificationFailure() throws ParseException, VerifiableCredentialException, MalformedURLException {
+        Credential credential = CredentialTest.buildCredential();
+        KeyPair keyPair1 = Keys.keyPairFor(SignatureAlgorithm.ES256K);
+
+        JwtVerifiableCredential vc = new JwtVerifiableCredential(
+                credential, "ES256K", credential.getIssuer().getId() + "#key1", keyPair1.getPrivate()
+        );
+
+        KeyPair keyPair2 = Keys.keyPairFor(SignatureAlgorithm.ES256K);
+        vc.verify(keyPair2.getPublic());
+    }
+}

--- a/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentationTest.java
+++ b/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentationTest.java
@@ -1,0 +1,45 @@
+package org.medibloc.vc.verifiable.jwt;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.Test;
+import org.medibloc.vc.VerifiableCredentialException;
+import org.medibloc.vc.model.Presentation;
+import org.medibloc.vc.model.PresentationTest;
+
+import java.net.MalformedURLException;
+import java.security.KeyPair;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class JwtVerifiablePresentationTest {
+    @Test
+    public void createAndVerify() throws MalformedURLException, VerifiableCredentialException {
+        Presentation presentation = PresentationTest.buildPresentation();
+        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256K);
+
+        JwtVerifiablePresentation vp = new JwtVerifiablePresentation(
+                presentation, "ES256K", presentation.getHolder() + "#key1", keyPair.getPrivate()
+        );
+        assertNotNull(vp);
+
+        System.out.println(vp.serialize());
+
+        assertEquals(presentation, vp.verify(keyPair.getPublic()));
+        assertEquals(vp.getJws(), vp.serialize());
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void verificationFailure() throws MalformedURLException, VerifiableCredentialException {
+        Presentation presentation = PresentationTest.buildPresentation();
+        KeyPair keyPair1 = Keys.keyPairFor(SignatureAlgorithm.ES256K);
+
+        JwtVerifiablePresentation vp = new JwtVerifiablePresentation(
+                presentation, "ES256K", presentation.getHolder() + "#key1", keyPair1.getPrivate()
+        );
+
+        KeyPair keyPair2 = Keys.keyPairFor(SignatureAlgorithm.ES256K);
+        vp.verify(keyPair2.getPublic());
+    }
+}


### PR DESCRIPTION
Close #2 
Close #3 

I implemented the logic for creating/verifying W3C Verifiable Credentials/Presentations. 
For usages, please see README.

Currently, this PR was implemented with the following minimum spec:
- Verification is done by [java.security.Key](https://javadoc.scijava.org/Java6/java/security/Key.html). In the future, it should be resolved from DID documents.
- Only the external proof (JWT) is supported. The embedded proof (LD proof) is not supported yet. For more details, please see https://www.w3.org/TR/vc-data-model/#proofs-signatures.
- Its behavior is compatible with [did-jwt-vc](https://github.com/decentralized-identity/did-jwt-vc) written in Typescript by DIF. So, I expect I don't need to implement our own `vc-js` SDK.

TODO:
- Integrate with the DID resolution.