### PR TITLE
feat: Add nonce to VC and VP

### DIFF
--- a/src/main/java/org/medibloc/vc/verifiable/VerifiableCredential.java
+++ b/src/main/java/org/medibloc/vc/verifiable/VerifiableCredential.java
@@ -16,7 +16,7 @@ import java.security.interfaces.ECPublicKey;
 @JsonDeserialize(using = VerifiableCredential.JsonDeserializer.class)
 public interface VerifiableCredential {
     public Credential getCredential() throws VerifiableCredentialException;
-    public void verify(ECPublicKey publicKey) throws VerifiableCredentialException;
+    public void verify(ECPublicKey publicKey, String nonce) throws VerifiableCredentialException;
     public String getKeyId() throws VerifiableCredentialException;
     public String serialize();
 

--- a/src/main/java/org/medibloc/vc/verifiable/VerifiablePresentation.java
+++ b/src/main/java/org/medibloc/vc/verifiable/VerifiablePresentation.java
@@ -7,7 +7,7 @@ import java.security.interfaces.ECPublicKey;
 
 public interface VerifiablePresentation {
     public Presentation getPresentation() throws VerifiableCredentialException;
-    public void verify(ECPublicKey publicKey) throws VerifiableCredentialException;
+    public void verify(ECPublicKey publicKey, String nonce) throws VerifiableCredentialException;
     public String getKeyId() throws VerifiableCredentialException;
     public String serialize();
 }

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
@@ -23,7 +23,7 @@ import java.text.ParseException;
 @Getter
 @EqualsAndHashCode
 class JwtVerifiable {
-    // For preventing a holder from impersonating the issuer
+    // For preventing a holder (or a verifier) from impersonating the issuer (or the holder).
     // https://www.w3.org/TR/2019/REC-vc-data-model-20191119/#example-28-jwt-payload-of-a-jwt-based-verifiable-credential-using-jws-as-a-proof-non-normative
     private static final String JWT_CLAIM_NAME_NONCE = "nonce";
 

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiable.java
@@ -23,18 +23,25 @@ import java.text.ParseException;
 @Getter
 @EqualsAndHashCode
 class JwtVerifiable {
+    // For preventing a holder from impersonating the issuer
+    // https://www.w3.org/TR/2019/REC-vc-data-model-20191119/#example-28-jwt-payload-of-a-jwt-based-verifiable-credential-using-jws-as-a-proof-non-normative
+    private static final String JWT_CLAIM_NAME_NONCE = "nonce";
+
     @JsonValue
     @NonNull
     private final String jwt;
 
-    JwtVerifiable(String algo, String keyId, ECPrivateKey privateKey, JWTClaimsSet jwtClaimsSet) throws VerifiableCredentialException {
+    JwtVerifiable(String algo, String keyId, ECPrivateKey privateKey, JWTClaimsSet.Builder jwtClaimsSetBuilder, String nonce) throws VerifiableCredentialException {
         Assert.notNull(algo, "keyType must not be null");
         Assert.notNull(keyId, "keyId must not be null");
         Assert.notNull(privateKey, "privateKey must not be null");
-        Assert.notNull(jwtClaimsSet, "jwtClaimsSet must not be null");
+        Assert.notNull(jwtClaimsSetBuilder, "jwtClaimsSetBuilder must not be null");
+        Assert.notNull(nonce, "nonce must not be null");
+
+        jwtClaimsSetBuilder.claim(JWT_CLAIM_NAME_NONCE, nonce);
 
         JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.parse(algo)).keyID(keyId).build();
-        SignedJWT jwt = new SignedJWT(jwsHeader, jwtClaimsSet);
+        SignedJWT jwt = new SignedJWT(jwsHeader, jwtClaimsSetBuilder.build());
         try {
             jwt.sign(new ECDSASigner(privateKey));
             this.jwt = jwt.serialize();
@@ -43,9 +50,15 @@ class JwtVerifiable {
         }
     }
 
-    void verifyJwt(ECPublicKey publicKey) throws VerifiableCredentialException {
+    void verifyJwt(ECPublicKey publicKey, String nonce) throws VerifiableCredentialException {
         try {
             SignedJWT jwt = SignedJWT.parse(this.jwt);
+
+            String nonceInJwt = (String) jwt.getJWTClaimsSet().getClaims().get(JWT_CLAIM_NAME_NONCE);
+            if (nonceInJwt == null || !nonceInJwt.equals(nonce)) {
+                throw new VerifiableCredentialException("JWT nonce doesn't match. Expected:" + nonce + ", Actual:" + nonceInJwt);
+            }
+
             if (!jwt.verify(new ECDSAVerifier(publicKey))) {
                 throw new VerifiableCredentialException("JWT verification failed");
             }

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredential.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredential.java
@@ -35,8 +35,8 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_E
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class JwtVerifiableCredential extends JwtVerifiable implements VerifiableCredential {
-    public JwtVerifiableCredential(Credential credential, String jwsAlgo, String keyId, ECPrivateKey privateKey) throws VerifiableCredentialException {
-        super(jwsAlgo, keyId, privateKey, encode(credential));
+    public JwtVerifiableCredential(Credential credential, String jwsAlgo, String keyId, ECPrivateKey privateKey, String nonce) throws VerifiableCredentialException {
+        super(jwsAlgo, keyId, privateKey, encode(credential), nonce);
     }
 
     public JwtVerifiableCredential(String jwt) {
@@ -49,8 +49,8 @@ public class JwtVerifiableCredential extends JwtVerifiable implements Verifiable
     }
 
     @Override
-    public void verify(ECPublicKey publicKey) throws VerifiableCredentialException {
-        super.verifyJwt(publicKey);
+    public void verify(ECPublicKey publicKey, String nonce) throws VerifiableCredentialException {
+        super.verifyJwt(publicKey, nonce);
     }
 
     // https://www.w3.org/TR/vc-data-model/#json-web-token-extensions
@@ -60,8 +60,7 @@ public class JwtVerifiableCredential extends JwtVerifiable implements Verifiable
     /**
      * Encode a credential to a JWT payload, as described at https://www.w3.org/TR/vc-data-model/#jwt-encoding
      */
-    private static JWTClaimsSet encode(Credential credential) {
-
+    private static JWTClaimsSet.Builder encode(Credential credential) {
         // Set JWT registered claims (iss, exp, ...)
         JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
                 .issuer(credential.getIssuer().getId())
@@ -80,7 +79,7 @@ public class JwtVerifiableCredential extends JwtVerifiable implements Verifiable
         builder.claim(JWT_CLAIM_NAME_VC, VcClaim.from(credential).toMap());
         builder.claim(JWT_CLAIM_NAME_ISSUER, credential.getIssuer().getExtras());
 
-        return builder.build();
+        return builder;
     }
 
     /**

--- a/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentation.java
+++ b/src/main/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentation.java
@@ -34,8 +34,8 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_SINGLE_E
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class JwtVerifiablePresentation extends JwtVerifiable implements VerifiablePresentation {
-    public JwtVerifiablePresentation(Presentation presentation, String jwsAlgo, String keyId, ECPrivateKey privateKey) throws VerifiableCredentialException {
-        super(jwsAlgo, keyId, privateKey, encode(presentation));
+    public JwtVerifiablePresentation(Presentation presentation, String jwsAlgo, String keyId, ECPrivateKey privateKey, String nonce) throws VerifiableCredentialException {
+        super(jwsAlgo, keyId, privateKey, encode(presentation), nonce);
     }
 
     public JwtVerifiablePresentation(String jwt) {
@@ -48,8 +48,8 @@ public class JwtVerifiablePresentation extends JwtVerifiable implements Verifiab
     }
 
     @Override
-    public void verify(ECPublicKey publicKey) throws VerifiableCredentialException {
-        super.verifyJwt(publicKey);
+    public void verify(ECPublicKey publicKey, String nonce) throws VerifiableCredentialException {
+        super.verifyJwt(publicKey, nonce);
     }
 
     // https://www.w3.org/TR/vc-data-model/#json-web-token-extensions
@@ -58,7 +58,7 @@ public class JwtVerifiablePresentation extends JwtVerifiable implements Verifiab
     /**
      * Encode a presentation to a JWT payload.
      */
-    private static JWTClaimsSet encode(Presentation presentation) {
+    private static JWTClaimsSet.Builder encode(Presentation presentation) {
         // Set JWT registered claims (iss, exp, ...)
         JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder().issuer(presentation.getHolder());
         if (presentation.getId() != null) {
@@ -68,7 +68,7 @@ public class JwtVerifiablePresentation extends JwtVerifiable implements Verifiab
         // Set JWT private claims
         builder.claim(JWT_CLAIM_NAME_VP, VpClaim.from(presentation).toMap());
 
-        return builder.build();
+        return builder;
     }
 
     /**

--- a/src/test/java/org/medibloc/vc/key/KeyDecoderTest.java
+++ b/src/test/java/org/medibloc/vc/key/KeyDecoderTest.java
@@ -33,11 +33,12 @@ public class KeyDecoderTest {
 
     private void assertKeyPair(ECPrivateKey privateKey, ECPublicKey publicKey) throws ParseException, VerifiableCredentialException, MalformedURLException {
         Credential credential = CredentialTest.buildCredential();
+        String nonce = "this-is-random";
         JwtVerifiableCredential vc = new JwtVerifiableCredential(
-                credential, "ES256K", credential.getIssuer().getId() + "#key1", privateKey
+                credential, "ES256K", credential.getIssuer().getId() + "#key1", privateKey, nonce
         );
         assertNotNull(vc);
         assertEquals(credential, vc.getCredential());
-        vc.verify(publicKey);
+        vc.verify(publicKey, nonce);
     }
 }

--- a/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredentialTest.java
+++ b/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiableCredentialTest.java
@@ -23,13 +23,14 @@ public class JwtVerifiableCredentialTest {
         Credential credential = CredentialTest.buildCredential();
         ECKey ecJWK = new ECKeyGenerator(Curve.SECP256K1).generate();
 
+        String nonce = "this-is-random";
         JwtVerifiableCredential vc = new JwtVerifiableCredential(
-                credential, "ES256K", credential.getIssuer().getId() + "#key1", ecJWK.toECPrivateKey()
+                credential, "ES256K", credential.getIssuer().getId() + "#key1", ecJWK.toECPrivateKey(), nonce
         );
         assertNotNull(vc);
 
         assertEquals(credential, vc.getCredential());
-        vc.verify(ecJWK.toECPublicKey());
+        vc.verify(ecJWK.toECPublicKey(), nonce);
         assertEquals(vc.getJwt(), vc.serialize());
     }
 
@@ -38,22 +39,35 @@ public class JwtVerifiableCredentialTest {
         Credential credential = CredentialTest.buildCredential();
         ECKey ecJWK = new ECKeyGenerator(Curve.SECP256K1).generate();
 
-
         new JwtVerifiableCredential(
-                credential, "INVALID", credential.getIssuer().getId() + "#key1", ecJWK.toECPrivateKey()
+                credential, "INVALID", credential.getIssuer().getId() + "#key1", ecJWK.toECPrivateKey(), "this-is-random"
         );
     }
 
     @Test(expected = VerifiableCredentialException.class)
-    public void verificationFailure() throws ParseException, VerifiableCredentialException, MalformedURLException, JOSEException {
+    public void signatureVerificationFailure() throws ParseException, VerifiableCredentialException, MalformedURLException, JOSEException {
         Credential credential = CredentialTest.buildCredential();
         ECKey ecJWK1 = new ECKeyGenerator(Curve.SECP256K1).generate();
 
+        String nonce = "this-is-random";
         JwtVerifiableCredential vc = new JwtVerifiableCredential(
-                credential, "ES256K", credential.getIssuer().getId() + "#key1", ecJWK1.toECPrivateKey()
+                credential, "ES256K", credential.getIssuer().getId() + "#key1", ecJWK1.toECPrivateKey(), nonce
         );
 
         ECKey ecJWK2 = new ECKeyGenerator(Curve.SECP256K1).generate();
-        vc.verify(ecJWK2.toECPublicKey());
+        vc.verify(ecJWK2.toECPublicKey(), nonce);
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void nonceVerificationFailure() throws ParseException, VerifiableCredentialException, MalformedURLException, JOSEException {
+        Credential credential = CredentialTest.buildCredential();
+        ECKey ecJWK = new ECKeyGenerator(Curve.SECP256K1).generate();
+
+        String nonce = "this-is-random";
+        JwtVerifiableCredential vc = new JwtVerifiableCredential(
+                credential, "ES256K", credential.getIssuer().getId() + "#key1", ecJWK.toECPrivateKey(), nonce
+        );
+
+        vc.verify(ecJWK.toECPublicKey(), "wrong-nonce");
     }
 }

--- a/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentationTest.java
+++ b/src/test/java/org/medibloc/vc/verifiable/jwt/JwtVerifiablePresentationTest.java
@@ -20,28 +20,43 @@ public class JwtVerifiablePresentationTest {
         Presentation presentation = PresentationTest.buildPresentation();
         ECKey ecJWK = new ECKeyGenerator(Curve.SECP256K1).generate();
 
+        final String nonce = "this-is-random";
         JwtVerifiablePresentation vp = new JwtVerifiablePresentation(
-                presentation, "ES256K", presentation.getHolder() + "#key1", ecJWK.toECPrivateKey()
+                presentation, "ES256K", presentation.getHolder() + "#key1", ecJWK.toECPrivateKey(), nonce
         );
         assertNotNull(vp);
 
         System.out.println(vp.serialize());
 
         assertEquals(presentation, vp.getPresentation());
-        vp.verify(ecJWK.toECPublicKey());
+        vp.verify(ecJWK.toECPublicKey(), nonce);
         assertEquals(vp.getJwt(), vp.serialize());
     }
 
     @Test(expected = VerifiableCredentialException.class)
-    public void verificationFailure() throws MalformedURLException, VerifiableCredentialException, JOSEException {
+    public void signatureVerificationFailure() throws MalformedURLException, VerifiableCredentialException, JOSEException {
         Presentation presentation = PresentationTest.buildPresentation();
         ECKey ecJWK1 = new ECKeyGenerator(Curve.SECP256K1).generate();
 
+        final String nonce = "this-is-random";
         JwtVerifiablePresentation vp = new JwtVerifiablePresentation(
-                presentation, "ES256K", presentation.getHolder() + "#key1", ecJWK1.toECPrivateKey()
+                presentation, "ES256K", presentation.getHolder() + "#key1", ecJWK1.toECPrivateKey(), nonce
         );
 
         ECKey ecJWK2 = new ECKeyGenerator(Curve.SECP256K1).generate();
-        vp.verify(ecJWK2.toECPublicKey());
+        vp.verify(ecJWK2.toECPublicKey(), nonce);
+    }
+
+    @Test(expected = VerifiableCredentialException.class)
+    public void nonceVerificationFailure() throws MalformedURLException, VerifiableCredentialException, JOSEException {
+        Presentation presentation = PresentationTest.buildPresentation();
+        ECKey ecJWK = new ECKeyGenerator(Curve.SECP256K1).generate();
+
+        final String nonce = "this-is-random";
+        JwtVerifiablePresentation vp = new JwtVerifiablePresentation(
+                presentation, "ES256K", presentation.getHolder() + "#key1", ecJWK.toECPrivateKey(), nonce
+        );
+
+        vp.verify(ecJWK.toECPublicKey(), "wrong-nonce");
     }
 }


### PR DESCRIPTION
For preventing a holder from impersonating the issuer
or 
For preventing a verifier from impersonating the holder

Reference: https://www.w3.org/TR/2019/REC-vc-data-model-20191119/#example-28-jwt-payload-of-a-jwt-based-verifiable-credential-using-jws-as-a-proof-non-normative